### PR TITLE
Generalized `new()` constructor to take non-file based markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Instantiate a new Transcoder instance with a JSON, YAML, or TOML path and use `.
 use markup_converter::Transcoder;
 
 fn main() -> anyhow::Result<()> {
-  let transcoder = Transcoder::new("tests/test.yaml")?;
+  let transcoder = Transcoder::from_path("tests/test.yaml")?;
 
   let json_val = transcoder.to_json()?;
 
@@ -19,5 +19,3 @@ fn main() -> anyhow::Result<()> {
   Ok(())
 }
 ```
-
-

--- a/examples/jaq.rs
+++ b/examples/jaq.rs
@@ -2,7 +2,7 @@ use jaq_core::{parse, Ctx, Definitions, Val};
 use markup_converter::Transcoder;
 
 fn main() -> anyhow::Result<()> {
-    let input = Transcoder::new("tests/test.yaml")?.to_json()?;
+    let input = Transcoder::from_path("tests/test.yaml")?.to_json()?;
 
     let filter = ".name";
 
@@ -13,7 +13,7 @@ fn main() -> anyhow::Result<()> {
 
     // parse the filter in the context of the given definitions
     let mut errs = Vec::new();
-    let f = parse::parse(&filter, parse::main()).0.unwrap();
+    let f = parse::parse(filter, parse::main()).0.unwrap();
     let f = defs.finish(f, Vec::new(), &mut errs);
 
     // iterator over the output values

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,4 +77,4 @@
 mod error;
 mod transcoder;
 
-pub use transcoder::Transcoder;
+pub use transcoder::{Format, Transcoder};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,12 +1,12 @@
-use markup_converter::Transcoder;
+use markup_converter::{Format, Transcoder};
 
 use anyhow::Result;
 
 #[test]
 fn test_to_json() -> Result<()> {
-    let yaml_converter = Transcoder::new("tests/test.yaml")?;
-    let json_converter = Transcoder::new("tests/test.json")?;
-    let toml_converter = Transcoder::new("tests/test.toml")?;
+    let yaml_converter = Transcoder::from_path("tests/test.yaml")?;
+    let json_converter = Transcoder::from_path("tests/test.json")?;
+    let toml_converter = Transcoder::from_path("tests/test.toml")?;
 
     let yaml_jsonified = yaml_converter.to_json()?;
     let json_jsonified = json_converter.to_json()?;
@@ -19,9 +19,24 @@ fn test_to_json() -> Result<()> {
 
 #[test]
 fn test_to_yaml() -> Result<()> {
-    let yaml_converter = Transcoder::new("tests/test.yaml")?;
-    let json_converter = Transcoder::new("tests/test.json")?;
-    let toml_converter = Transcoder::new("tests/test.toml")?;
+    let yaml_converter = Transcoder::from_path("tests/test.yaml")?;
+    let json_converter = Transcoder::from_path("tests/test.json")?;
+    let toml_converter = Transcoder::from_path("tests/test.toml")?;
+
+    let yaml_jsonified = yaml_converter.to_yaml()?;
+    let json_jsonified = json_converter.to_yaml()?;
+    let toml_jsonified = toml_converter.to_yaml()?;
+
+    assert_eq!(yaml_jsonified, json_jsonified);
+    assert_eq!(yaml_jsonified, toml_jsonified);
+    Ok(())
+}
+
+#[test]
+fn test_new() -> Result<()> {
+    let yaml_converter = Transcoder::new(Format::yaml("---\nname: TestName")?)?;
+    let json_converter = Transcoder::new(Format::json("{\"name\":\"TestName\"}")?)?;
+    let toml_converter = Transcoder::new(Format::toml("name = \"TestName\"")?)?;
 
     let yaml_jsonified = yaml_converter.to_yaml()?;
     let json_jsonified = json_converter.to_yaml()?;


### PR DESCRIPTION
This PR expands `Transcoder` to take markup that doesn't come from the filesystem. The previous version assumed that all markup would come from a file so it could infer the type from the extension, this version moves that functionality to `Transcoder::from_path()` and creates a more generic `Transcoder::new()` that takes a `Format` value.

As a result of the new `new()`, this PR also makes the `Format` type public.